### PR TITLE
Fix: allegati che spariscono quando manca la decorazione salvata

### DIFF
--- a/autoloads/ocmultibinaryoperators.php
+++ b/autoloads/ocmultibinaryoperators.php
@@ -39,7 +39,11 @@ class OCMultiBinaryOperators
                         $groups = [];
                         $files = $attribute->content();
                         foreach ($files as $file) {
-                            $groups[] = $file->attribute('display_group');
+                            // Un file senza decorazione salvata ha display_group non
+                            // inizializzato (null): normalizzarlo a stringa evita che
+                            // finisca fuori dal bucket "senza nome" ('') per un confronto
+                            // stretto più avanti.
+                            $groups[] = (string)$file->attribute('display_group');
                         }
                         $groups = array_unique($groups);
                         sort($groups);
@@ -57,11 +61,25 @@ class OCMultiBinaryOperators
                     $group = $namedParameters['group'];
                     $fileList = [];
                     foreach ($attribute->content() as $file) {
-                        if ($file->attribute('display_group') == $group) {
-                            $fileList[$file->attribute('display_order')] = $file;
+                        if ((string)$file->attribute('display_group') === (string)$group) {
+                            $fileList[] = $file;
                         }
                     }
-                    ksort($fileList);
+                    // display_order non è garantito: un file senza decorazione salvata
+                    // ha valore null. Usarlo come chiave d'array (come prima) fa
+                    // collassare più file sulla stessa chiave (null diventa '') e
+                    // solo l'ultimo processato resta visibile. Ordinare con usort e
+                    // mandare in coda gli ordini mancanti evita che un file scompaia.
+                    usort($fileList, function ($a, $b) {
+                        $orderA = $a->attribute('display_order');
+                        $orderB = $b->attribute('display_order');
+                        $orderA = $orderA === null ? PHP_INT_MAX : (int)$orderA;
+                        $orderB = $orderB === null ? PHP_INT_MAX : (int)$orderB;
+                        if ($orderA === $orderB) {
+                            return 0;
+                        }
+                        return $orderA < $orderB ? -1 : 1;
+                    });
                     $operatorValue = $fileList;
                 }
                 break;

--- a/tests/ocmultibinary_operators_test.php
+++ b/tests/ocmultibinary_operators_test.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Test standalone (nessun framework, nessun kernel eZ Publish richiesto) per
+ * OCMultiBinaryOperators::modify(). Copre il bug per cui un file senza una
+ * decorazione salvata (display_order/display_group non inizializzati, quindi
+ * null) faceva sparire altri file nel rendering frontend, e verifica che il
+ * comportamento corretto pre-esistente non sia cambiato.
+ *
+ * Esecuzione: php tests/ocmultibinary_operators_test.php
+ */
+
+// Stub minimo: basta l'interfaccia usata dagli operatori (attribute/setAttribute),
+// non serve estendere la vera eZMultiBinaryFile (che richiede il kernel/DB).
+class StubMultiBinaryFile
+{
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function attribute($name)
+    {
+        return array_key_exists($name, $this->data) ? $this->data[$name] : null;
+    }
+
+    public function setAttribute($name, $value)
+    {
+        $this->data[$name] = $value;
+    }
+}
+
+// ocmultibinary_available_groups fa `instanceof eZContentObjectAttribute`.
+// La vera classe non è caricata (nessun kernel eZ Publish in questo test), quindi
+// definiamo uno stub omonimo solo per soddisfare il type-check.
+class eZContentObjectAttribute
+{
+    private $files;
+
+    public function __construct(array $files)
+    {
+        $this->files = $files;
+    }
+
+    public function content()
+    {
+        return $this->files;
+    }
+}
+
+require __DIR__ . '/../autoloads/ocmultibinaryoperators.php';
+
+$failures = [];
+$passed = 0;
+
+function run_operator($operatorName, $namedParameters)
+{
+    $ops = new OCMultiBinaryOperators();
+    $tpl = null;
+    $operatorParameters = [];
+    $rootNamespace = null;
+    $currentNamespace = null;
+    $operatorValue = null;
+    $ops->modify($tpl, $operatorName, $operatorParameters, $rootNamespace, $currentNamespace, $operatorValue, $namedParameters);
+    return $operatorValue;
+}
+
+function check($label, $condition)
+{
+    global $failures, $passed;
+    if ($condition) {
+        $passed++;
+    } else {
+        $failures[] = $label;
+    }
+}
+
+function filenames($fileList)
+{
+    // array_values: a noi interessa l'ordine dei valori, non le chiavi
+    // dell'array intermedio (il codice originale, non corretto, usa
+    // display_order come chiave e quindi non reindicizza da 0).
+    return array_values(array_map(function ($f) {
+        return $f->attribute('original_filename');
+    }, $fileList));
+}
+
+// --- Caso base: decorazioni tutte presenti, ordine e gruppo espliciti ---
+// Nessuna regressione attesa: stesso identico comportamento di prima del fix.
+$a = new StubMultiBinaryFile(['original_filename' => 'a.pdf', 'display_group' => '', 'display_order' => 2]);
+$b = new StubMultiBinaryFile(['original_filename' => 'b.pdf', 'display_group' => '', 'display_order' => 1]);
+$c = new StubMultiBinaryFile(['original_filename' => 'c.pdf', 'display_group' => 'Bandi', 'display_order' => 1]);
+$attribute = new eZContentObjectAttribute([$a, $b, $c]);
+
+$result = run_operator('ocmultibinary_list_by_group', ['attribute' => $attribute, 'group' => '']);
+check('caso base: entrambi i file del gruppo vuoto presenti', filenames($result) === ['b.pdf', 'a.pdf']);
+
+$result = run_operator('ocmultibinary_list_by_group', ['attribute' => $attribute, 'group' => 'Bandi']);
+check('caso base: il gruppo "Bandi" non include file di altri gruppi', filenames($result) === ['c.pdf']);
+
+// --- Caso del bug: un file senza decorazione salvata (display_order/display_group = null) ---
+// Prima del fix: il file "orfano" (order=null) collassava sulla stessa chiave
+// array di qualunque altro file con order=null, facendone sparire uno.
+// Qui simuliamo 2 file orfani insieme a uno regolare: TUTTI devono restare.
+$orphan1 = new StubMultiBinaryFile(['original_filename' => 'orphan1.pdf', 'display_group' => null, 'display_order' => null]);
+$orphan2 = new StubMultiBinaryFile(['original_filename' => 'orphan2.pdf', 'display_group' => null, 'display_order' => null]);
+$decorated = new StubMultiBinaryFile(['original_filename' => 'decorated.pdf', 'display_group' => '', 'display_order' => 1]);
+$attribute = new eZContentObjectAttribute([$decorated, $orphan1, $orphan2]);
+
+$result = run_operator('ocmultibinary_list_by_group', ['attribute' => $attribute, 'group' => '']);
+check(
+    'regressione bug: nessun file orfano scompare (tutti e 3 presenti)',
+    count($result) === 3
+);
+check(
+    'regressione bug: il file decorato resta primo, gli orfani in coda',
+    filenames($result)[0] === 'decorated.pdf'
+);
+check(
+    'regressione bug: entrambi gli orfani presenti indipendentemente dall\'ordine di elaborazione',
+    in_array('orphan1.pdf', filenames($result)) && in_array('orphan2.pdf', filenames($result))
+);
+
+// --- Edge case correlato: due file con lo stesso display_order impostato manualmente ---
+// (es. redattore digita "1" nel campo Sort di due file diversi). Anche qui,
+// usare l'ordine come chiave d'array farebbe sparire uno dei due.
+$dup1 = new StubMultiBinaryFile(['original_filename' => 'dup1.pdf', 'display_group' => '', 'display_order' => 5]);
+$dup2 = new StubMultiBinaryFile(['original_filename' => 'dup2.pdf', 'display_group' => '', 'display_order' => 5]);
+$attribute = new eZContentObjectAttribute([$dup1, $dup2]);
+
+$result = run_operator('ocmultibinary_list_by_group', ['attribute' => $attribute, 'group' => '']);
+check('edge case: due file con stesso display_order restano entrambi visibili', count($result) === 2);
+
+// --- ocmultibinary_available_groups: un file orfano (display_group=null) non deve
+// rompere il riordino "gruppo senza nome per ultimo" ---
+$grouped = new StubMultiBinaryFile(['original_filename' => 'g.pdf', 'display_group' => 'Bandi']);
+$orphan = new StubMultiBinaryFile(['original_filename' => 'o.pdf', 'display_group' => null]);
+$attribute = new eZContentObjectAttribute([$grouped, $orphan]);
+
+$result = run_operator('ocmultibinary_available_groups', ['attribute' => $attribute]);
+check(
+    'available_groups: il gruppo "senza nome" (anche se orfano/null) va in coda',
+    $result === ['Bandi', '']
+);
+
+// --- Riepilogo ---
+echo $passed . " test passati, " . count($failures) . " falliti.\n";
+if ($failures) {
+    foreach ($failures as $f) {
+        echo "  FALLITO: " . $f . "\n";
+    }
+    exit(1);
+}
+exit(0);


### PR DESCRIPTION
## Problema

Riferimento: [gitlab opencity-labs/sito-istituzionale/cms#327](https://gitlab.com/opencity-labs/sito-istituzionale/cms/-/issues/327), ticket Freshdesk [#30041](https://opencontent.freshdesk.com/a/tickets/30041) e [#28953](https://opencontent.freshdesk.com/a/tickets/28953).

Su Documenti e Avvisi con più allegati (classe con "allow decorations" attivo), alcuni allegati caricati risultano invisibili nel frontend anche se effettivamente salvati e scaricabili via URL diretto. Il workaround noto e documentato in supporto: riordinare gli allegati con le freccette nell'editor "sblocca" la visualizzazione.

## Causa

`display_order` e `display_group` su `eZMultiBinaryFile` **non sono colonne del database** (vedi `classes/ezmultibinaryfile.php`): sono proprietà PHP popolate solo se `getBinaryFiles()` trova una voce corrispondente nel blob serializzato `data_text`. Un file che per qualsiasi motivo non ha una decorazione salvata resta con questi valori a `null` (default PHP, mai inizializzato).

In `autoloads/ocmultibinaryoperators.php`, l'operatore `ocmultibinary_list_by_group` usava `display_order` come **chiave di un array**:

```php
$fileList[$file->attribute('display_order')] = $file;
```

Se due o più file hanno `display_order = null` (chiave che PHP casta a `''`), o anche solo lo stesso valore intero (es. inserito manualmente nel campo "Sort"), si sovrascrivono a vicenda: **solo l'ultimo elaborato resta nell'array**, gli altri spariscono silenziosamente dal rendering — pur restando scaricabili, perché la lista dei file scaricabili viene letta altrove (`getBinaryFiles()`), non da questo operatore.

Il workaround (riordinare con le freccette) funziona perché chiama `setFileOrder()`, l'unico metodo che assegna un ordine numerico esplicito a **tutti** i file attualmente mostrati nell'editor, "sanando" così qualunque decorazione mancante.

`ocmultibinary_available_groups` aveva un problema collegato: il confronto `$groups[0] === ''` (stretto) falliva silenziosamente se il gruppo "senza nome" superstite dopo `array_unique()` era `null` invece della stringa `''`, saltando il riordino "gruppo senza nome in fondo".

## Fix

- `ocmultibinary_list_by_group`: non si usa più `display_order` come chiave d'array. I file vengono accumulati in una lista e ordinati con `usort`, trattando un ordine mancante (`null`) come "manda in fondo" invece di "sovrascrivi un altro file". Il confronto sul gruppo usa un cast a stringa esplicito per includere in modo prevedibile i file senza `display_group` nel bucket "senza nome" (comportamento preesistente, preservato).
- `ocmultibinary_available_groups`: stesso cast a stringa su `display_group` prima di `array_unique`/`sort`, per evitare che un gruppo "senza nome" rappresentato da `null` invece di `''` salti il riordino finale.

Nessuna modifica al formato di `data_text`, alla logica di storage, o al comportamento quando tutte le decorazioni sono presenti e valide: il fix interviene solo nel percorso in cui una decorazione manca.

## Verifica

**Unit test** (`tests/ocmultibinary_operators_test.php`, standalone — nessuna dipendenza da PHPUnit né dal kernel eZ Publish, uso stub minimi):

```
php tests/ocmultibinary_operators_test.php
7 test passati, 0 falliti.
```

Confermato che la suite catturi davvero la regressione: rieseguendo gli stessi test sul codice precedente al fix, i 2 test sul caso base (nessuna decorazione mancante) passano — nessuna regressione sul comportamento già corretto — mentre i 5 test che riproducono il bug e i casi limite collegati (file con `display_order` duplicato manualmente) falliscono come previsto.

**Verifica end-to-end** su un documento reale in un ambiente eZ Publish live (non solo unit test):
1. Simulato nel DB lo scenario esatto del bug: 4 file realmente presenti in `ezbinaryfile`, ma solo 2 con una voce corrispondente in `data_text`.
2. **Senza il fix**: uno dei due file "orfani" spariva davvero dal link di download nella pagina pubblica.
3. **Con il fix**: tutti e 4 gli allegati tornano visibili, stesso identico stato del database.

Testato anche il caso normale (nessuna decorazione mancante, più allegati aggiunti in una o più sessioni di editing) per confermare l'assenza di regressioni sul comportamento quotidiano.

## Nota per il deploy

Dopo l'aggiornamento del codice, un semplice `ezcache.php --clear-all` non è sufficiente per vedere l'effetto del fix nel frontend — serve anche un reload di PHP-FPM, perché OPcache continua a servire il bytecode precedente fino alla successiva ricompilazione.
